### PR TITLE
Fix compilation under gcc 7.

### DIFF
--- a/library/eventual/detail/utility.h
+++ b/library/eventual/detail/utility.h
@@ -56,8 +56,7 @@ namespace eventual
 
         inline std::future_error CreateFutureError(std::future_errc error)
         {
-            auto code = std::make_error_code(error);
-            return std::future_error(code);
+            return std::future_error(error);
         }
 
         inline std::exception_ptr CreateFutureExceptionPtr(std::future_errc error)


### PR DESCRIPTION
Fixes the following compile error under recent gcc's libstdc++:

```cpp
eventual/library/eventual/detail/utility.h: In function ‘std::future_error eventual::detail::CreateFutureError(std::future_errc)’:
eventual/library/eventual/detail/utility.h:60:42: error: ‘std::future_error::future_error(std::error_code)’ is private within this context
             return std::future_error(code);
                                          ^

/usr/include/c++/7.1.1/future:114:5: note: declared private here
     future_error(error_code __ec)
     ^~~~~~~~~~~~
```

Tested under g++5, g++7, clang 6 (svn). Also tested with clang6 + libc++; compiles with and without the change.