### PR TITLE
Fix for Travis CI builds not completing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,11 @@ matrix:
    fast-finish: true
       
 env:
-   global:
-      - DOCKER_NAME=rferraro/cxx-travis-ci
    matrix:
-      - DOCKER_TAG=clang-3.7.1 CONFIGURATION=Debug
-      - DOCKER_TAG=clang-3.7.1 CONFIGURATION=Release
-      - DOCKER_TAG=gcc-5.3.0   CONFIGURATION=Debug
-      - DOCKER_TAG=gcc-5.3.0   CONFIGURATION=Release
+      - DOCKER_NAME=rferraro/cxx-clang DOCKER_TAG=3.7.1 CONFIGURATION=Debug
+      - DOCKER_NAME=rferraro/cxx-clang DOCKER_TAG=3.7.1 CONFIGURATION=Release
+      - DOCKER_NAME=rferraro/cxx-gcc   DOCKER_TAG=5.3.0 CONFIGURATION=Debug
+      - DOCKER_NAME=rferraro/cxx-gcc   DOCKER_TAG=5.3.0 CONFIGURATION=Release
 
 install:
    - docker pull "${DOCKER_NAME}:${DOCKER_TAG}"

--- a/tools/docker/build-project.sh
+++ b/tools/docker/build-project.sh
@@ -64,6 +64,14 @@ fi
 mkdir -p $BuildPath
 pushd $BuildPath
 
+echo "Installing latest Conan C/C++ package manager."
+pip install conan
+conan --version
+
+# Update conan data directory for caching by the CI environment.
+echo "Setting conan data path to: /tmp/conan"
+conan config set storage.path=/tmp/conan
+
 echo "Configuring: cmake -DCMAKE_BUILD_TYPE=\"${CONFIGURATION}\" $SourcePath"
 cmake -DCMAKE_BUILD_TYPE="${CONFIGURATION}" $SourcePath
 


### PR DESCRIPTION
A fix for Issue #2:
* Changed the Travis CI configuration to not use docker images which included outdated versions of the conan package manager.
* Updated the docker build script so it always installs the latest version of the conan package manager.