### PR TITLE
Add explicit std:: to move/forward.

### DIFF
--- a/library/eventual/detail/implementation.h
+++ b/library/eventual/detail/implementation.h
@@ -544,7 +544,7 @@ namespace eventual
                 };
 
                 thread_local ExitNotifier notifier;
-                notifier.Add(move(block));
+                notifier.Add(std::move(block));
             }
 
             bool SetHasResult()
@@ -1121,8 +1121,8 @@ namespace eventual
 
                 return
                     [
-                        task = forward<task_t>(task),
-                        argument = forward<TArgType>(argument)
+                        task = std::forward<task_t>(task),
+                        argument = std::forward<TArgType>(argument)
                     ]() mutable { task(argument); };
             }
 
@@ -1136,9 +1136,9 @@ namespace eventual
 
                 return
                     [
-                        task = forward<task_t>(task),
-                        argument = forward<TArgType>(argument)
-                    ]() mutable { task(move(argument)); };
+                        task = std::forward<task_t>(task),
+                        argument = std::forward<TArgType>(argument)
+                    ]() mutable { task(std::move(argument)); };
             }
 
             template<class TFunctor, class TResultType, class TArgType>
@@ -1151,9 +1151,9 @@ namespace eventual
 
                 return
                     [
-                        task = forward<task_t>(task),
-                        argument = forward<TArgType>(argument)
-                    ]() mutable { task(move(argument)); };
+                        task = std::forward<task_t>(task),
+                        argument = std::forward<TArgType>(argument)
+                    ]() mutable { task(std::move(argument)); };
             }
 
             void ResetState()

--- a/library/eventual/eventual.h
+++ b/library/eventual/eventual.h
@@ -481,7 +481,7 @@ namespace eventual
         using namespace eventual::detail;
         using result_t = when_any_result<tuple<decay_t<Futures>...>>;
 
-        auto futuresSequence = make_tuple<decay_t<Futures>...>(forward<Futures>(futures)...);
+        auto futuresSequence = make_tuple<decay_t<Futures>...>(std::forward<Futures>(futures)...);
         auto indexPromise = make_shared<promise<size_t>>();
         auto indexfuture = indexPromise->get_future();
 
@@ -559,11 +559,11 @@ namespace eventual
             using namespace std;
             using task_t = get_continuation_task_t<TFuture, TContinuation>;
 
-            auto current = forward<TFuture>(future);
+            auto current = std::forward<TFuture>(future);
             auto state = current.ValidateState();
             auto allocator = state->Get_Allocator();
 
-            task_t task(allocator_arg_t(), allocator, forward<TContinuation>(continuation));
+            task_t task(allocator_arg_t(), allocator, std::forward<TContinuation>(continuation));
             auto taskFuture = GetUnwrappedFuture(task);
 
             state->SetCallback(CreateCallback(std::move(task), std::move(current)));
@@ -579,7 +579,7 @@ namespace eventual
         {
             using namespace std;
 
-            auto tailfuture = When_All_(forward<Futures>(others)...);
+            auto tailfuture = When_All_(std::forward<Futures>(others)...);
             return tailfuture.then([head = move(head)](auto& tf) mutable
             {
                 return head.then([tf = move(tf)](auto& h) mutable

--- a/library/eventual/eventual.h
+++ b/library/eventual/eventual.h
@@ -409,13 +409,13 @@ namespace eventual
         {
             auto& future = *iterator;
             vectorfuture = vectorfuture.then(
-                [future = move(future)](auto& vf) mutable
+                [future = std::move(future)](auto& vf) mutable
             {
                 return future.then(
-                    [vf = move(vf)](auto& future) mutable
+                    [vf = std::move(vf)](auto& future) mutable
                 {
                     auto resultVector = vf.get();
-                    resultVector.emplace_back(move(future));
+                    resultVector.emplace_back(std::move(future));
                     return resultVector;
                 });
             });
@@ -448,7 +448,7 @@ namespace eventual
         size_t index = 0;
         for (auto iterator = first; iterator != last; ++iterator)
         {
-            futures.emplace_back(move(*iterator));
+            futures.emplace_back(std::move(*iterator));
 
             FutureHelper::SetCallback(futures.back(),
                         [indexPromise, index]()
@@ -467,7 +467,7 @@ namespace eventual
         {
             result_t result;
             result.index = firstIndex.get();
-            result.futures = move(sequence);
+            result.futures = std::move(sequence);
 
             return result;
         });
@@ -498,11 +498,11 @@ namespace eventual
         });
 
         return indexfuture.then(
-            [sequence = move(futuresSequence)](auto& firstIndex) mutable
+            [sequence = std::move(futuresSequence)](auto& firstIndex) mutable
         {
             result_t result;
             result.index = firstIndex.get();
-            result.futures = move(sequence);
+            result.futures = std::move(sequence);
 
             return result;
         });
@@ -580,11 +580,11 @@ namespace eventual
             using namespace std;
 
             auto tailfuture = When_All_(std::forward<Futures>(others)...);
-            return tailfuture.then([head = move(head)](auto& tf) mutable
+            return tailfuture.then([head = std::move(head)](auto& tf) mutable
             {
-                return head.then([tf = move(tf)](auto& h) mutable
+                return head.then([tf = std::move(tf)](auto& h) mutable
                 {
-                    return tuple_cat(make_tuple(move(h)), tf.get());
+                    return tuple_cat(make_tuple(std::move(h)), tf.get());
                 });
             });
         }


### PR DESCRIPTION
Fixes ambiguities in environments with multiple definitions.

Note that some of the existing references already explicitly used `std::`, these commits unify to it.